### PR TITLE
feat(surface): export custom surface types

### DIFF
--- a/crates/surface-wasmtime/src/lib.rs
+++ b/crates/surface-wasmtime/src/lib.rs
@@ -1,7 +1,7 @@
 mod surface;
 pub use surface::{
-    add_to_linker as add_surface_to_linker, MainThreadSpawner, Surface, SurfaceCtx, SurfaceCtxView,
-    SurfaceDesc,
+    add_to_linker as add_surface_to_linker, GfxWindow, Key, KeyEvent, MainThreadSpawner,
+    PointerEvent, ResizeEvent, Surface, SurfaceCtx, SurfaceCtxView, SurfaceDesc,
 };
 
 #[cfg(feature = "winit")]

--- a/crates/surface-wasmtime/src/surface.rs
+++ b/crates/surface-wasmtime/src/surface.rs
@@ -3,7 +3,7 @@ use shared::channel_to_stream;
 use std::{fmt::Debug, future::Future, marker::PhantomData, pin::Pin, sync::Arc};
 use wasi_gfx::surface::surface;
 pub use wasi_gfx::surface::surface::{
-    FrameEvent, KeyEvent, PointerEvent, {CreateDesc as SurfaceDesc, ResizeEvent},
+    FrameEvent, Key, KeyEvent, PointerEvent, {CreateDesc as SurfaceDesc, ResizeEvent},
 };
 use wasmtime::component::{Access, HasData, Resource, StreamReader};
 


### PR DESCRIPTION
Export GfxWindow and event types so runtime can attach custom surfaces from non-winit windows.
